### PR TITLE
Added peer dependencies to 0.9.0-rc or 0.10.0-rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/brentvatne/react-native-scrollable-tab-view#readme",
   "peerDependencies": {
-    "react-native": ">=0.8.0 || 0.8.0-rc || 0.8.0-rc.2"
+    "react-native": ">=0.8.0 || 0.8.0-rc || 0.8.0-rc.2 || 0.9.0-rc || 0.10.0-rc"
   },
   "dependencies": {
     "rebound": "0.0.13"


### PR DESCRIPTION
Small bug - I think there's a problem with the styling of the CustomTabBar when I upgraded 0.9.0, but now I want to upgrade to 0.10.0-rc for the Modals, so can you upgrade the peer dependencies?