### PR TITLE
throw custom error if less than 2 children

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,9 @@ var ScrollableTabView = React.createClass({
   },
 
   componentWillMount() {
+    if(!this.props.children.length) {
+      throw new Error('You need more than one page to use this plugin!');
+    }
     var release = (e, gestureState) => {
       var relativeGestureDistance = gestureState.dx / deviceWidth,
           lastPageIndex = this.props.children.length - 1,


### PR DESCRIPTION
If only one child is present `this.props.children` is not an array anymore. You then can't run all the Array.prototype function on it.

Demo:

`<ScrollableTabView>
          <Homepage tabLabel="React"></Homepage>
        </ScrollableTabView>`

Result:

![](http://i.imgur.com/ytI5ZTQ.png)