### PR TITLE
Expose DefaultTabBar to enable customization via inheritance

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ var DefaultTabBar = require('./DefaultTabBar');
 var deviceWidth = Dimensions.get('window').width;
 
 var ScrollableTabView = React.createClass({
+  statics: {
+    DefaultTabBar: DefaultTabBar 
+  },
   getDefaultProps() {
     return {
       edgeHitWidth: 30,


### PR DESCRIPTION
I suspect a lot of users simply want to adjust styling and minor behaviors for the tab bar, so it would be quite helpful to be able to simply build a custom tab bar by inheriting the default component rather than requiring a complete rewrite.