### PR TITLE
Add initialPage prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ module.exports = CustomTabBar;
 - **`springTension`** _(Integer)_ - a number between `1` and `100`, controls the amount of tension on the spring that guides the scroll animation - see [example](http://facebook.github.io/rebound-js/examples/#graph-canvas).
 - **`springFriction`** _(Integer)_ - a number between `1` and `30`, controls the amount of friction on the spring that guides the scroll animation - see [example](http://facebook.github.io/rebound-js/examples/#graph-canvas).
 - **`clampSpring`** _(Bool)_ - if `true`, the spring will not bounce at all - if `false`, it will oscillate around the target value before settling.
+- **`initialPage`** _(Integer)_ - the index of the initially selected tab, defaults to 0 === first tab.
 - **`children`** _(ReactComponents)_ - each top-level child component should have a `tabLabel` prop that can be used by the tab bar component to render out the labels. The default tab bar expects it to be a string, but you can use anything you want if you make a custom tab bar.
 
 ---

--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ var ScrollableTabView = React.createClass({
   },
 
   getInitialState() {
-    return { currentPage: 0, scrollValue: new Animated.Value(0) };
+    var currentPage = this.props.initialPage || 0;
+    return { currentPage: currentPage, scrollValue: new Animated.Value(currentPage) };
   },
 
   componentWillMount() {


### PR DESCRIPTION
This PR adds an `initialPage` prop to set which tab is the one selected by default on render. Useful if application was opened by a quick action or if you simply don't want the first tab to be default. 