### PR TITLE
Implement ViewPager on Android instead of ScrollView.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,14 @@ module.exports = CustomTabBar;
   be able to animate itself along with the tab content.
 - **`tabBarPosition`** _(String)_ - if `"top"`, the tab bar will render above the tabs. If `"bottom"`, the tab bar will render below the tabs. Defaults to `"top"`.
 - **`onChangeTab`** _(Function)_ - function to call when tab changes, should accept 1 argument which is an Object containing two keys: `i`: the index of the tab that is selected, `ref`: the ref of the tab that is selected
+- **`useAlwaysScrollView`** _(Bool)_ - if `true`, the even on Android ScrollView will be used. Default: `false`
 - **`edgeHitWidth`** _(Integer)_ - region (in pixels) from the left & right edges of the screen that can trigger swipe. Default is 30, which is the same as the swipe-back gesture on iOS.
-- **`hasTouch`** _(Function)_ - returns `true` when ScrollableTabView starts being panned and `false` when it is released. Not triggered when `locked` (Bool) is true.
-- **`locked`** _(Bool)_ - dynamically disable scrolling between tabs.
-- **`springTension`** _(Integer)_ - a number between `1` and `100`, controls the amount of tension on the spring that guides the scroll animation - see [example](http://facebook.github.io/rebound-js/examples/#graph-canvas).
-- **`springFriction`** _(Integer)_ - a number between `1` and `30`, controls the amount of friction on the spring that guides the scroll animation - see [example](http://facebook.github.io/rebound-js/examples/#graph-canvas).
+- **`hasTouch`** _(Function)_ - returns `true` when ScrollableTabView starts being panned and `false` when it is released. Not triggered when `locked` (Bool) is true. Only when useAlwaysScrollView is true on Android.
+- **`locked`** _(Bool)_ - dynamically disable scrolling between tabs. Only when useAlwaysScrollView is true on Android.
+- **`springTension`** _(Integer)_ - a number between `1` and `100`, controls the amount of tension on the spring that guides the scroll animation - see [example](http://facebook.github.io/rebound-js/examples/#graph-canvas). Only when useAlwaysScrollView is true on Android.
+- **`springFriction`** _(Integer)_ - a number between `1` and `30`, controls the amount of friction on the spring that guides the scroll animation - see [example](http://facebook.github.io/rebound-js/examples/#graph-canvas). Only when useAlwaysScrollView is true on Android.
 - **`clampSpring`** _(Bool)_ - if `true`, the spring will not bounce at all - if `false`, it will oscillate around the target value before settling.
-- **`initialPage`** _(Integer)_ - the index of the initially selected tab, defaults to 0 === first tab.
+- **`initialPage`** _(Integer)_ - the index of the initially selected tab, defaults to 0 === first tab. Only when useAlwaysScrollView is true on Android.
 - **`children`** _(ReactComponents)_ - each top-level child component should have a `tabLabel` prop that can be used by the tab bar component to render out the labels. The default tab bar expects it to be a string, but you can use anything you want if you make a custom tab bar.
 
 ---

--- a/index.js
+++ b/index.js
@@ -8,19 +8,27 @@ var {
   TouchableOpacity,
   PanResponder,
   Animated,
+  Platform,
+  ViewPagerAndroid
 } = React;
 
 var DefaultTabBar = require('./DefaultTabBar');
 var deviceWidth = Dimensions.get('window').width;
 
 var ScrollableTabView = React.createClass({
+  // Export DefaultTabBar
+  statics: {
+    DefaultTabBar: DefaultTabBar
+  },
+
   getDefaultProps() {
     return {
       tabBarPosition: 'top',
       edgeHitWidth: 30,
       springTension: 50,
-      springFriction: 10
-    }
+      springFriction: 10,
+      useAlwaysScrollView: false
+    };
   },
 
   getInitialState() {
@@ -77,14 +85,41 @@ var ScrollableTabView = React.createClass({
 
   goToPage(pageNumber) {
     this.props.onChangeTab && this.props.onChangeTab({
-      i: pageNumber, ref: this.props.children[pageNumber]
+      i: pageNumber,
+      ref: this.props.children[pageNumber]
     });
 
     this.setState({
-      currentPage: pageNumber
+      currentPage: pageNumber,
     });
 
+    if( Platform.OS == 'android' && !this.props.useAlwaysScrollView )  {
+      this.viewPager.setPage(pageNumber);
+    }
+
     Animated.spring(this.state.scrollValue, {toValue: pageNumber, friction: this.props.springFriction, tension: this.props.springTension}).start();
+  },
+
+  /**
+   * Method to handle ViewPager on Android
+   *
+   * @param  {Object} e
+   */
+  onPageScroll: function(e){
+    var pageNumber = this.viewPager.state.selectedPage;
+
+    if( pageNumber != this.state.currentPage ) {
+      this.props.onChangeTab && this.props.onChangeTab({
+        i: pageNumber,
+        ref: this.props.children[pageNumber]
+      });
+
+      this.setState({
+        currentPage: pageNumber,
+      });
+
+      Animated.spring(this.state.scrollValue, {toValue: pageNumber, friction: this.props.springFriction, tension: this.props.springTension}).start();
+    }
   },
 
   renderTabBar(props) {
@@ -115,13 +150,30 @@ var ScrollableTabView = React.createClass({
       scrollValue: this.state.scrollValue
     };
 
+    var component = (
+      <Animated.View style={[sceneContainerStyle, {transform: [{translateX}]}]}
+        {...this._panResponder.panHandlers}>
+        {this.props.children}
+      </Animated.View>
+    );
+
+    // Use ViewPager on Android
+    if( Platform.OS == 'android' && !this.props.useAlwaysScrollView )  {
+      component = (
+        <ViewPagerAndroid ref={(vp) => { this.viewPager = vp; }}
+          onPageScroll={this.onPageScroll}
+          style={sceneContainerStyle}
+          initialPage={this.state.currentPage}
+          >
+          {this.props.children}
+        </ViewPagerAndroid>
+      );
+    }
+
     return (
       <View style={{flex: 1}}>
         {this.props.tabBarPosition === 'top' ? this.renderTabBar(tabBarProps) : null}
-        <Animated.View style={[sceneContainerStyle, {transform: [{translateX}]}]}
-          {...this._panResponder.panHandlers}>
-          {this.props.children}
-        </Animated.View>
+        {component}
         {this.props.tabBarPosition === 'bottom' ? this.renderTabBar(tabBarProps) : null}
       </View>
     );

--- a/index.js
+++ b/index.js
@@ -134,10 +134,14 @@ var ScrollableTabView = React.createClass({
 
   render() {
     var sceneContainerStyle = {
-      width: deviceWidth * this.props.children.length,
       flex: 1,
       flexDirection: 'row'
     };
+    
+    // Adjust size only on iOS
+    if( Platform.OS == 'ios' || this.props.useAlwaysScrollView ) {
+      sceneContainerStyle.width = deviceWidth * this.props.children.length;
+    }
 
     var translateX = this.state.scrollValue.interpolate({
       inputRange: [0, 1], outputRange: [0, -deviceWidth]


### PR DESCRIPTION
Implemented ViewPager on Android with a Property to disable it. Export the DefaultTabBar to make it extendible with ES6. Re-implement methods with ViewPager.