### PR TITLE
Add locked prop functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See
 - **`onChangeTab`** _(Function)_ - function to call when tab changes, should accept 1 argument which is an Object containing two keys: `i`: the index of the tab that is selected, `ref`: the ref of the tab that is selected
 - **`edgeHitWidth`** _(Integer)_ - region (in pixels) from the left & right edges of the screen that can trigger swipe. Default is 30, which is the same as the swipe-back gesture on iOS.
 - **`hasTouch`** _(Function)_ - returns `true` when ScrollableTabView starts being panned and `false` when it is released. Not triggered when `locked` (Bool) is true.
-- **`locked`** _(Bool)_ - dynamically disable scrolling between tabs.
+- **`locked`** _(Bool)_ - disables horizontal dragging to scroll between tabs, default is false.
 - **`springTension`** _(Integer)_ - a number between `1` and `100`, controls the amount of tension on the spring that guides the scroll animation - see [example](http://facebook.github.io/rebound-js/examples/#graph-canvas).
 - **`springFriction`** _(Integer)_ - a number between `1` and `30`, controls the amount of friction on the spring that guides the scroll animation - see [example](http://facebook.github.io/rebound-js/examples/#graph-canvas).
 - **`clampSpring`** _(Bool)_ - if `true`, the spring will not bounce at all - if `false`, it will oscillate around the target value before settling.

--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ var ScrollableTabView = React.createClass({
           }}
           scrollEventThrottle={16}
           showsHorizontalScrollIndicator={false}
+          scrollEnabled={!this.props.locked}
           directionalLockEnabled
           alwaysBounceVertical={false}>
           {this.props.children}


### PR DESCRIPTION
I noticed that although the readme describes a locked prop that prevents horizontal scrolling, it doesn't actually seem to work. I added the functionality back into index and updated the readme to match.