### PR TITLE
throwing an error message if only one tab exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ var ScrollableTabView = React.createClass({
   },
 
   renderScrollableContent() {
+    if (this.props.children instanceof Object) { throw "Need to have more then one child element."; }
     if (Platform.OS === 'ios') {
       return (
         <ScrollView


### PR DESCRIPTION
Issue: https://github.com/brentvatne/react-native-scrollable-tab-view/issues/61