### PR TITLE
Made tab content flex vertically to fill view

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ var ScrollableTabView = React.createClass({
           horizontal
           pagingEnabled
           style={styles.scrollableContentIOS}
+          contentContainerStyle={styles.scrollableContentContainerIOS}
           contentOffset={{x:this.props.initialPage * this.state.container.width}}
           ref={(scrollView) => { this.scrollView = scrollView }}
           onScroll={(e) => {
@@ -190,8 +191,11 @@ var styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  scrollableContentContainerIOS: {
+    flex: 1,
+  },
   scrollableContentIOS: {
-    flexDirection: 'row',
+    flexDirection: 'column',
   },
   scrollableContentAndroid: {
     flex: 1,


### PR DESCRIPTION
Had the same problem as discussed in #108. That is, my tab content did not fill view vertically. This fix, made my tabs flex to fill the whole view. closes #108