### PR TITLE
Check for initialPage to be set before comparing it to currentPage

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ var ScrollableTabView = React.createClass({
   },
 
   componentWillReceiveProps(props) {
-    if (props.initialPage !== this.state.currentPage) {
+    if (props.initialPage && props.initialPage !== this.state.currentPage) {
       this.goToPage(props.initialPage);
     }
   },


### PR DESCRIPTION
This fixes #114 for me and I think it makes sense. If an initialPage is not set, then it shouldn't do this comparison and erase previous history on a prop update.