### PR TITLE
Fix: Tab returns to initial page on change of state

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,12 +51,6 @@ var ScrollableTabView = React.createClass({
     };
   },
 
-  componentWillReceiveProps(props) {
-    if (props.initialPage && props.initialPage !== this.state.currentPage) {
-      this.goToPage(props.initialPage);
-    }
-  },
-
   goToPage(pageNumber) {
     this.props.onChangeTab({ i: pageNumber, ref: this._children()[pageNumber] });
 


### PR DESCRIPTION
Running react-native 0.17.0

There does not seem to be any detrimental effects from removing this code.

Can still set `initialPage` as prop