### PR TITLE
Fix faulty onMomentumScroll integral-page-width assumption

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ var ScrollableTabView = React.createClass({
           }}
           onMomentumScrollEnd={(e) => {
             var offsetX = e.nativeEvent.contentOffset.x;
-            this._updateSelectedPage(parseInt(offsetX / this.state.container.width));
+            this._updateSelectedPage(parseInt(offsetX / this.state.container.width + 0.5));
           }}
           scrollEventThrottle={16}
           showsHorizontalScrollIndicator={false}


### PR DESCRIPTION
This pull request compensates for a quirk (feature?) in `onMomentumScrollEnd` + `ScrollView` in which it fires before (I think; maybe after?) an integer multiple of the element width is reached. The line of interest is:

```javascript
onMomentumScrollEnd={(e) => {
  var offsetX = e.nativeEvent.contentOffset.x;
  this._updateSelectedPage(parseInt(offsetX / this.state.container.width));
}
```

I added a console log to this function:

```javascript
console.log(
  offsetX,
  this.state.container.width,
  offsetX / this.state.container.width,
  parseInt(offsetX / this.state.container.width)
)
```

The first number should be an integer multiple of the second, and the last two should be the same integer. That's usually true except I sometimes get, e.g.:

```javascript
373.5 375 0.996 0
```

It appears `onMomentumScrollEnd doesn't fire precisely at page width multiples.

Round to the nearest integer by adding 0.5; problem solved?

```javascript
this._updateSelectedPage(parseInt(offsetX / this.state.container.width + 0.5));
```
