### PR TITLE
Backwards compatible access to props.children

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,9 @@ var ScrollableTabView = React.createClass({
     }
   },
 
+  // The following implementation allows for compatibility with version
+  // of React Native that depend on React.Children prior to
+  // facebook/react#6013105a9cf625cac18851683adbf2fd19b6833c
   _children() {
     var result = [];
     React.Children.forEach(this.props.children, (child) => result.push(child));

--- a/index.js
+++ b/index.js
@@ -168,7 +168,9 @@ var ScrollableTabView = React.createClass({
   },
 
   _children() {
-    return React.Children.map(this.props.children, (child) => child);
+    var result = [];
+    React.Children.forEach(this.props.children, (child) => result.push(child));
+    return result;
   },
 
   render() {


### PR DESCRIPTION
I am wondering if you would be willing to take the approach in this PR in order to access the `props.children` as an array, which is compatible with React Native 0.15 and up.

The [React.Children.map](https://github.com/facebook/react/blob/b4e74e38e43ac53af8acd62c78c9213be0194245/src/isomorphic/children/ReactChildren.js#L117-L127) used by React Native 0.15 does not return an array, which causes an exception using react-native-scrollable-tab-view.

This works in the latest [React.Children.map](https://github.com/facebook/react/blob/master/src/isomorphic/children/ReactChildren.js#L157-L164) because the function returns an array.

I thought the implementation in this PR could be a compromise to allow for using this library on React Native 0.15. I am open to other ideas though. 