### PR TITLE
Adds 'overlayTabs' prop + example

### DIFF
--- a/DefaultTabBar.js
+++ b/DefaultTabBar.js
@@ -71,7 +71,7 @@ var DefaultTabBar = React.createClass({
     });
 
     return (
-      <View style={[styles.tabs, {backgroundColor : this.props.backgroundColor || null}]}>
+      <View style={[this.props.style, styles.tabs, {backgroundColor : this.props.backgroundColor || null}]}>
         {this.props.tabs.map((tab, i) => this.renderTabOption(tab, i))}
         <Animated.View style={[tabUnderlineStyle, {left}]} />
       </View>

--- a/README.md
+++ b/README.md
@@ -70,13 +70,14 @@ See
   the tab bar. The component has `goToPage`, `tabs`, `activeTab` and
   `ref` added to the props, and should implement `setAnimationValue` to
   be able to animate itself along with the tab content.
-- **`tabBarPosition`** _(String)_ - if `"top"`, the tab bar will render above the tabs. If `"bottom"`, the tab bar will render below the tabs. Defaults to `"top"`.
+- **`tabBarPosition`** _(String)_ Defaults to `"top"`.
+  - `"bottom"` to position the tab bar below content.
+  - `"overlayTop"` or `"overlayBottom"` for a semitransparent tab bar that overlays content. Custom tab bars must consume a style prop on their outer element to support this feature: `style={this.props.style}`.
 - **`onChangeTab`** _(Function)_ - function to call when tab changes, should accept 1 argument which is an Object containing two keys: `i`: the index of the tab that is selected, `ref`: the ref of the tab that is selected
 - **`onScroll`** _(Function)_ - function to call when the pages are sliding, should accept 1 argument which is an Float number representing the page position in the slide frame. 
 - **`locked`** _(Bool)_ - disables horizontal dragging to scroll between tabs, default is false.
 - **`initialPage`** _(Integer)_ - the index of the initially selected tab, defaults to 0 === first tab.
 - **`page`** _(Integer)_ - set selected tab(can be buggy see  [#126](https://github.com/brentvatne/react-native-scrollable-tab-view/issues/126)
-- **`overlayTabs`** _(Bool)_ - for use with semitransparent tabs that overlap the content. Custom tab bars must include `style={this.props.style}` on their outer element to support this feature.
 - **`children`** _(ReactComponents)_ - each top-level child component should have a `tabLabel` prop that can be used by the tab bar component to render out the labels. The default tab bar expects it to be a string, but you can use anything you want if you make a custom tab bar.
 - **`tabBarUnderlineColor`** _(String)_ - color of the default tab bar's underline, defaults to `navy`
 - **`tabBarBackgroundColor`** _(String)_ - color of the default tab bar's background, defaults to `white`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 ## react-native-scrollable-tab-view
 
 This is probably my favorite navigation pattern on Android, I wish it
@@ -75,6 +76,7 @@ See
 - **`locked`** _(Bool)_ - disables horizontal dragging to scroll between tabs, default is false.
 - **`initialPage`** _(Integer)_ - the index of the initially selected tab, defaults to 0 === first tab.
 - **`page`** _(Integer)_ - set selected tab(can be buggy see  [#126](https://github.com/brentvatne/react-native-scrollable-tab-view/issues/126)
+- **`overlayTabs`** _(Bool)_ - for use with semitransparent tabs that overlap the content. Custom tab bars must include `style={this.props.style}` on their outer element to support this feature.
 - **`children`** _(ReactComponents)_ - each top-level child component should have a `tabLabel` prop that can be used by the tab bar component to render out the labels. The default tab bar expects it to be a string, but you can use anything you want if you make a custom tab bar.
 - **`tabBarUnderlineColor`** _(String)_ - color of the default tab bar's underline, defaults to `navy`
 - **`tabBarBackgroundColor`** _(String)_ - color of the default tab bar's background, defaults to `white`

--- a/examples/FacebookTabsExample/FacebookTabBar.js
+++ b/examples/FacebookTabsExample/FacebookTabBar.js
@@ -101,7 +101,7 @@ var FacebookTabBar = React.createClass({
 
     return (
       <View>
-        <View style={[this.props.style, styles.tabs]}>
+        <View style={[styles.tabs, this.props.style]}>
           {this.props.tabs.map((tab, i) => this.renderTabOption(tab, i))}
         </View>
         <Animated.View style={[tabUnderlineStyle, {left}]} />

--- a/examples/FacebookTabsExample/FacebookTabBar.js
+++ b/examples/FacebookTabsExample/FacebookTabBar.js
@@ -101,7 +101,7 @@ var FacebookTabBar = React.createClass({
 
     return (
       <View>
-        <View style={styles.tabs}>
+        <View style={[this.props.style, styles.tabs]}>
           {this.props.tabs.map((tab, i) => this.renderTabOption(tab, i))}
         </View>
         <Animated.View style={[tabUnderlineStyle, {left}]} />

--- a/examples/FacebookTabsExample/FacebookTabsExample.js
+++ b/examples/FacebookTabsExample/FacebookTabsExample.js
@@ -61,16 +61,16 @@ var SimpleExample = React.createClass({
   }
 });
 
-// Adding the prop overlayTabs lets the content to show through a semitransparent tab bar.
-// Note that if you build a custom tab bar component, its outer container must consume a
-// style prop (e.g. <View style={[this.props.style, etc]}) to support this feature.
-var OverlayTabsExample = React.createClass({
+// Using tabBarPosition='overlayTop' or 'overlayBottom' lets the content show through a
+// semitransparent tab bar. Note that if you build a custom tab bar component, its outer container
+// must consume a 'style' prop (e.g. <View style={this.props.style}) to support this feature.
+var OverlayExample = React.createClass({
   render() {
     return (
       <ScrollableTabView
         style={styles.container}
         renderTabBar={()=><DefaultTabBar backgroundColor='rgba(255, 255, 255, 0.5)' />}
-        overlayTabs
+        tabBarPosition='overlayTop'
         >
         <View tabLabel='Music' style={{flex:1, backgroundColor: '#CCFFFF'}}>
           <Icon name='ion|android-volume-up' color='#2222CC' size={300} style={styles.icon} />
@@ -88,7 +88,7 @@ var OverlayTabsExample = React.createClass({
 
 module.exports = FacebookTabsExample;
 // module.exports = SimpleExample;
-// module.exports = OverlayTabsExample;
+// module.exports = OverlayExample;
 
 var styles = StyleSheet.create({
   container: {

--- a/examples/FacebookTabsExample/FacebookTabsExample.js
+++ b/examples/FacebookTabsExample/FacebookTabsExample.js
@@ -10,6 +10,8 @@ var {
 
 var ScrollableTabView = require('react-native-scrollable-tab-view');
 var FacebookTabBar = require('./FacebookTabBar');
+var DefaultTabBar = require('react-native-scrollable-tab-view/DefaultTabBar');
+var { Icon } = require('react-native-icons');
 
 var FacebookTabsExample = React.createClass({
   render() {
@@ -59,8 +61,34 @@ var SimpleExample = React.createClass({
   }
 });
 
-//module.exports = SimpleExample;
+// Adding the prop overlayTabs lets the content to show through a semitransparent tab bar.
+// Note that if you build a custom tab bar component, its outer container must consume a
+// style prop (e.g. <View style={[this.props.style, etc]}) to support this feature.
+var OverlayTabsExample = React.createClass({
+  render() {
+    return (
+      <ScrollableTabView
+        style={styles.container}
+        renderTabBar={()=><DefaultTabBar backgroundColor='rgba(255, 255, 255, 0.5)' />}
+        overlayTabs
+        >
+        <View tabLabel='Music' style={{flex:1, backgroundColor: '#CCFFFF'}}>
+          <Icon name='ion|android-volume-up' color='#2222CC' size={300} style={styles.icon} />
+        </View>
+        <View tabLabel='Food' style={{flex:1, backgroundColor: '#CCBBDD'}}>
+          <Icon name='ion|ios-nutrition' color='#22AACC' size={300} style={styles.icon} />
+        </View>
+        <View tabLabel='Drink' style={{flex:1, backgroundColor: '#EEFF33'}}>
+          <Icon name='ion|ios-pint' color='#22FFCC' size={300} style={styles.icon} />
+        </View>
+      </ScrollableTabView>
+    )
+  }
+});
+
 module.exports = FacebookTabsExample;
+// module.exports = SimpleExample;
+// module.exports = OverlayTabsExample;
 
 var styles = StyleSheet.create({
   container: {
@@ -84,4 +112,9 @@ var styles = StyleSheet.create({
     shadowOpacity: 0.5,
     shadowRadius: 3,
   },
+  icon: {
+    width: 300,
+    height: 300,
+    alignSelf: 'center',
+  }
 });

--- a/index.js
+++ b/index.js
@@ -23,10 +23,9 @@ var ScrollableTabView = React.createClass({
   },
 
   propTypes: {
-    tabBarPosition: PropTypes.oneOf(['top', 'bottom']),
+    tabBarPosition: PropTypes.oneOf(['top', 'bottom', 'overlayTop', 'overlayBottom']),
     initialPage: PropTypes.number,
     page: PropTypes.number,
-    overlayTabs: PropTypes.bool,
     onChangeTab: PropTypes.func,
     onScroll: PropTypes.func,
     renderTabBar: PropTypes.any,
@@ -38,7 +37,6 @@ var ScrollableTabView = React.createClass({
       tabBarPosition: 'top',
       initialPage: 0,
       page: -1,
-      overlayTabs: false,
       onChangeTab: () => {},
       onScroll: () => {}
     }
@@ -174,6 +172,7 @@ var ScrollableTabView = React.createClass({
   },
 
   render() {
+    var overlayTabs = (this.props.tabBarPosition === 'overlayTop' || this.props.tabBarPosition === 'overlayBottom');
     var tabBarProps = {
       goToPage: this.goToPage,
       tabs: this._children().map((child) => child.props.tabLabel),
@@ -194,15 +193,20 @@ var ScrollableTabView = React.createClass({
     if (this.props.tabBarInactiveTextColor) {
       tabBarProps.inactiveTextColor = this.props.tabBarInactiveTextColor;
     }
-    if (this.props.overlayTabs) {
-      tabBarProps.style = {position: 'absolute', left: 0, right: 0, [this.props.tabBarPosition]: 0};
+    if (overlayTabs) {
+      tabBarProps.style = {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        [this.props.tabBarPosition === 'overlayTop' ? 'top' : 'bottom']: 0
+      };
     }
     
     return (
       <View style={[styles.container, this.props.style]} onLayout={this._handleLayout}>
-        {this.props.tabBarPosition === 'top' && !this.props.overlayTabs && this.renderTabBar(tabBarProps)}
+        {this.props.tabBarPosition === 'top' && this.renderTabBar(tabBarProps)}
         {this.renderScrollableContent()}
-        {(this.props.tabBarPosition === 'bottom' || this.props.overlayTabs) && this.renderTabBar(tabBarProps)}
+        {(this.props.tabBarPosition === 'bottom' || overlayTabs) && this.renderTabBar(tabBarProps)}
       </View>
     );
   }

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ var ScrollableTabView = React.createClass({
     tabBarPosition: PropTypes.oneOf(['top', 'bottom']),
     initialPage: PropTypes.number,
     page: PropTypes.number,
+    overlayTabs: PropTypes.bool,
     onChangeTab: PropTypes.func,
     onScroll: PropTypes.func,
     renderTabBar: PropTypes.any,
@@ -37,6 +38,7 @@ var ScrollableTabView = React.createClass({
       tabBarPosition: 'top',
       initialPage: 0,
       page: -1,
+      overlayTabs: false,
       onChangeTab: () => {},
       onScroll: () => {}
     }
@@ -192,12 +194,15 @@ var ScrollableTabView = React.createClass({
     if (this.props.tabBarInactiveTextColor) {
       tabBarProps.inactiveTextColor = this.props.tabBarInactiveTextColor;
     }
+    if (this.props.overlayTabs) {
+      tabBarProps.style = {position: 'absolute', left: 0, right: 0, [this.props.tabBarPosition]: 0};
+    }
     
     return (
       <View style={[styles.container, this.props.style]} onLayout={this._handleLayout}>
-        {this.props.tabBarPosition === 'top' ? this.renderTabBar(tabBarProps) : null}
+        {this.props.tabBarPosition === 'top' && !this.props.overlayTabs && this.renderTabBar(tabBarProps)}
         {this.renderScrollableContent()}
-        {this.props.tabBarPosition === 'bottom' ? this.renderTabBar(tabBarProps) : null}
+        {(this.props.tabBarPosition === 'bottom' || this.props.overlayTabs) && this.renderTabBar(tabBarProps)}
       </View>
     );
   }


### PR DESCRIPTION
Thought I would pass along some functionality that we added in our project, an `overlayTabs` prop that allows for semitransparent tabs that let the content show through.

I added an example to make this easy to demo and test for you and others.

A caveat: since cloneElement doesn't merge styles, custom tab bars will have to consume `this.props.style`. I mention that in a code comment on the example. (Inconvenient, but cloneWithProps doesn't preserve key/ref, which I know I need. Maybe you know a way to push a style onto a cloned element?)