### PR TITLE
ScrollableTabView add props width by default DeviceWidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ See
 - **`tabBarBackgroundColor`** _(String)_ - color of the default tab bar's background, defaults to `white`
 - **`tabBarActiveTextColor`** _(String)_ - color of the default tab bar's text when active, defaults to `navy`
 - **`tabBarInactiveTextColor`** _(String)_ - color of the default tab bar's text when inactive, defaults to `black`
-- **`style`** _([View.propTypes.style](https://facebook.github.io/react-native/docs/view.html#style))_
+- **`style`** _([View.propTypes.style](https://facebook.github.io/react-native/docs/view.html#style))
+- **`width`** _(Integer)_ - width of the ScrollableTabView, defaults is `deviceWidth`
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ var ScrollableTabView = React.createClass({
     onScroll: PropTypes.func,
     renderTabBar: PropTypes.any,
     style: View.propTypes.style,
+    width: PropTypes.number,
   },
 
   getDefaultProps() {
@@ -38,7 +39,8 @@ var ScrollableTabView = React.createClass({
       initialPage: 0,
       page: -1,
       onChangeTab: () => {},
-      onScroll: () => {}
+      onScroll: () => {},
+      width: deviceWidth,
     }
   },
 
@@ -47,7 +49,7 @@ var ScrollableTabView = React.createClass({
       currentPage: this.props.initialPage,
       scrollValue: new Animated.Value(this.props.initialPage),
       container: {
-        width: deviceWidth,
+        width: this.props.width,
         height: deviceHeight,
       }
     };


### PR DESCRIPTION
Image you need to have a ScrollableTabView into specific part of your View.
Before my pull request you can't do it because the width is fixed.
Right now you can pass a generic width  by props. I hope this feature is in line with your ideas.
Thank's
M 