### PR TITLE
Remove container height monitoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,6 @@ var {
 } = React;
 
 var DefaultTabBar = require('./DefaultTabBar');
-var deviceWidth = Dimensions.get('window').width;
-var deviceHeight = Dimensions.get('window').height;
 
 var ScrollableTabView = React.createClass({
   statics: {
@@ -46,10 +44,7 @@ var ScrollableTabView = React.createClass({
     return {
       currentPage: this.props.initialPage,
       scrollValue: new Animated.Value(this.props.initialPage),
-      container: {
-        width: deviceWidth,
-        height: deviceHeight,
-      }
+      containerWidth: Dimensions.get('window').width,
     };
   },
 
@@ -63,7 +58,7 @@ var ScrollableTabView = React.createClass({
     this.props.onChangeTab({ i: pageNumber, ref: this._children()[pageNumber] });
 
     if(Platform.OS === 'ios') {
-      var offset = pageNumber * this.state.container.width;
+      var offset = pageNumber * this.state.containerWidth;
       this.scrollView.scrollTo(0, offset);
     } else {
       this.scrollView.setPage(pageNumber);
@@ -90,19 +85,19 @@ var ScrollableTabView = React.createClass({
           pagingEnabled
           style={styles.scrollableContentIOS}
           contentContainerStyle={styles.scrollableContentContainerIOS}
-          contentOffset={{x:this.props.initialPage * this.state.container.width}}
+          contentOffset={{x:this.props.initialPage * this.state.containerWidth}}
           ref={(scrollView) => { this.scrollView = scrollView }}
           onScroll={(e) => {
             var offsetX = e.nativeEvent.contentOffset.x;
-            this._updateScrollValue(offsetX / this.state.container.width);
+            this._updateScrollValue(offsetX / this.state.containerWidth);
           }}
           onMomentumScrollBegin={(e) => {
             var offsetX = e.nativeEvent.contentOffset.x;
-            this._updateSelectedPage(parseInt(offsetX / this.state.container.width));
+            this._updateSelectedPage(parseInt(offsetX / this.state.containerWidth));
           }}
           onMomentumScrollEnd={(e) => {
             var offsetX = e.nativeEvent.contentOffset.x;
-            this._updateSelectedPage(parseInt(offsetX / this.state.container.width));
+            this._updateSelectedPage(parseInt(offsetX / this.state.containerWidth));
           }}
           scrollEventThrottle={16}
           showsHorizontalScrollIndicator={false}
@@ -112,7 +107,7 @@ var ScrollableTabView = React.createClass({
           {this._children().map((child,idx) => {
             return <View
               key={child.props.tabLabel + '_' + idx}
-              style={{width: this.state.container.width}}>
+              style={{width: this.state.containerWidth}}>
               {child}
             </View>
             })}
@@ -132,7 +127,7 @@ var ScrollableTabView = React.createClass({
          {this._children().map((child,idx) => {
            return <View
              key={child.props.tabLabel + '_' + idx}
-             style={{width: this.state.container.width}}>
+             style={{width: this.state.containerWidth}}>
              {child}
            </View>
          })}
@@ -156,11 +151,10 @@ var ScrollableTabView = React.createClass({
   },
 
   _handleLayout(e) {
-    var {width, height} = e.nativeEvent.layout;
-    var container = this.state.container;
-
-    if (width !== container.width || height !== container.height) {
-      this.setState({container: e.nativeEvent.layout});
+    var { width } = e.nativeEvent.layout;
+    
+    if (width !== this.state.containerWidth) {
+      this.setState({containerWidth: width});
       InteractionManager.runAfterInteractions(() => {
         this.goToPage(this.state.currentPage);
       });
@@ -177,7 +171,7 @@ var ScrollableTabView = React.createClass({
       tabs: this._children().map((child) => child.props.tabLabel),
       activeTab: this.state.currentPage,
       scrollValue: this.state.scrollValue,
-      containerWidth: this.state.container.width,
+      containerWidth: this.state.containerWidth,
     };
     
     if (this.props.tabBarUnderlineColor) {


### PR DESCRIPTION
As per discussion in https://github.com/brentvatne/react-native-scrollable-tab-view/issues/151

-

Since this component manages a horizontal scroll view, it makes sense that it should monitor its container width and re-page itself when necessary (e.g. re-layout after device rotation).

But I don't think it should monitor its height and update itself if the height changes, since that doesn't affect the internals of the component's pages. Specifically, I need to be able to freely change the height of a tab view when something else on the page is collapsed, but it's causing a conflict.

When I looked into the code I noticed that container.height is tracked but never actually applied to anything, it is only watched. So the heart of this PR is changing this logic:

    if (width !== this.state.container.width && height !== this.state.container.height) {...

to this:

    if (width !== this.state.containerWidth) {...

It solves the conflict for me and doesn't seem to change anything about the way tab views lay themselves out, including during device rotation.