### PR TITLE
new scrollTo syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ var ScrollableTabView = React.createClass({
 
     if(Platform.OS === 'ios') {
       var offset = pageNumber * this.state.container.width;
-      this.scrollView.scrollTo(0, offset);
+      this.scrollView.scrollTo({x: offset, y: 0});
     } else {
       this.scrollView.setPage(pageNumber);
     }


### PR DESCRIPTION
This PR changes the scrollTo syntax to the new one at https://github.com/facebook/react-native/commit/6941c4e027abb582d7cef0e7c3b9b7ebf51bc070.

DO NOT MERGE now, because this breaks backwards compatibility with RN < 0.20 and the old `scrollTo` syntax will continue to work for now. This needs to wait until at least 0.20 is released and you're willing to break backwards compatibility.

Incidentally @brentvatne this is another instance where being able to rely on `peerDependencies` would be helpful, per the discussion at https://github.com/facebook/react-native/pull/5556. API changes that break compatibility with old RN versions are inevitable, and I think peerDependencies are a more robust way of communicating that to library consumers than depending on them reading the release notes.