### PR TITLE
Fix deprecated scrollTo synthax

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const ScrollableTabView = React.createClass({
 
     if (Platform.OS === 'ios') {
       const offset = pageNumber * this.state.containerWidth;
-      this.scrollView.scrollTo(0, offset);
+      this.scrollView.scrollTo({x: offset, y: 0});
     } else {
       this.scrollView.setPage(pageNumber);
     }


### PR DESCRIPTION
Hello @brentvatne, thank you for the great work. I had spent days trying to implement a similar component myself only to realize yours met all my needs. So thanks for helping me make my app better!

I’m trying to keep a warning free console and I’ve noticed that using this component keeps throwing this : ```scrollTo(y, x, animated) is deprecated. Use scrollTo({x: 5, y: 5, animated: true}) instead.```. So here's a fix for that.