### PR TITLE
fixed deprecated scrollTo function

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,11 @@ const ScrollableTabView = React.createClass({
 
     if (Platform.OS === 'ios') {
       const offset = pageNumber * this.state.containerWidth;
-      this.scrollView.scrollTo(0, offset);
+      this.scrollView.scrollTo({
+        x: offset,
+        y: 0,
+        animated: true,
+      });
     } else {
       this.scrollView.setPage(pageNumber);
     }


### PR DESCRIPTION
Hi, the scrollTo Function (y,x,animated) is deprecated and fixed with this pull request