### PR TITLE
add automaticallyAdjustContentInsets prop to ScrollView

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ const ScrollableTabView = React.createClass({
         <ScrollView
           horizontal
           pagingEnabled
+          automaticallyAdjustContentInsets={false}
           style={styles.scrollableContentIOS}
           contentContainerStyle={styles.scrollableContentContainerIOS}
           contentOffset={{ x: this.props.initialPage * this.state.containerWidth, }}


### PR DESCRIPTION
This removes the warning "Warnings: ScrollView doesn't take rejection well - scrolls anyway" when using a listView inside a tab