### PR TITLE
Add 'contentProps' property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See
   - `"bottom"` to position the tab bar below content.
   - `"overlayTop"` or `"overlayBottom"` for a semitransparent tab bar that overlays content. Custom tab bars must consume a style prop on their outer element to support this feature: `style={this.props.style}`.
 - **`onChangeTab`** _(Function)_ - function to call when tab changes, should accept 1 argument which is an Object containing two keys: `i`: the index of the tab that is selected, `ref`: the ref of the tab that is selected
-- **`onScroll`** _(Function)_ - function to call when the pages are sliding, should accept 1 argument which is an Float number representing the page position in the slide frame. 
+- **`onScroll`** _(Function)_ - function to call when the pages are sliding, should accept 1 argument which is an Float number representing the page position in the slide frame.
 - **`locked`** _(Bool)_ - disables horizontal dragging to scroll between tabs, default is false.
 - **`initialPage`** _(Integer)_ - the index of the initially selected tab, defaults to 0 === first tab.
 - **`page`** _(Integer)_ - set selected tab(can be buggy see  [#126](https://github.com/brentvatne/react-native-scrollable-tab-view/issues/126)
@@ -84,6 +84,7 @@ See
 - **`tabBarActiveTextColor`** _(String)_ - color of the default tab bar's text when active, defaults to `navy`
 - **`tabBarInactiveTextColor`** _(String)_ - color of the default tab bar's text when inactive, defaults to `black`
 - **`style`** _([View.propTypes.style](https://facebook.github.io/react-native/docs/view.html#style))_
+- **`contentProps`** _(Object)_ - props that are applied to root `ScrollView`/`ViewPagerAndroid`. Note that overriding defaults set by the library may break functionality; see the source for details.
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const ScrollableTabView = React.createClass({
     onScroll: PropTypes.func,
     renderTabBar: PropTypes.any,
     style: View.propTypes.style,
+    contentProps: PropTypes.object
   },
 
   getDefaultProps() {
@@ -104,7 +105,8 @@ const ScrollableTabView = React.createClass({
           showsHorizontalScrollIndicator={false}
           scrollEnabled={!this.props.locked}
           directionalLockEnabled
-          alwaysBounceVertical={false}>
+          alwaysBounceVertical={false}
+          {...this.props.contentProps}>
           {this._children().map((child, idx) => {
             return <View
               key={child.props.tabLabel + '_' + idx}
@@ -124,7 +126,8 @@ const ScrollableTabView = React.createClass({
            const { offset, position, } = e.nativeEvent;
            this._updateScrollValue(position + offset);
          }}
-         ref={(scrollView) => { this.scrollView = scrollView; }}>
+         ref={(scrollView) => { this.scrollView = scrollView; }}
+         {...this.props.contentProps}>
          {this._children().map((child, idx) => {
            return <View
              key={child.props.tabLabel + '_' + idx}

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ const ScrollableTabView = React.createClass({
       page: -1,
       onChangeTab: () => {},
       onScroll: () => {},
+      contentProps: {}
     };
   },
 


### PR DESCRIPTION
This allows configuration of the enclosed scrollView so callers can
workaround this bug: https://github.com/facebook/react-native/issues/4087

#175 