### PR TITLE
Added passGoToPage props to pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ const ScrollableTabView = React.createClass({
             return <View
               key={child.props.tabLabel + '_' + idx}
               style={{width: this.state.containerWidth, }}>
-              {child.props.hasOwnProperty('passGoToPage') ?
+              {child.props.passGoToPage ?
               React.cloneElement(child, {goToPage: this.goToPage}) : child}
             </View>;
           })}
@@ -136,7 +136,7 @@ const ScrollableTabView = React.createClass({
            return <View
              key={child.props.tabLabel + '_' + idx}
              style={{width: this.state.containerWidth, }}>
-             {child.props.hasOwnProperty('passGoToPage') ?
+             {child.props.passGoToPage ?
               React.cloneElement(child, {goToPage: this.goToPage}) : child}
            </View>;
          })}

--- a/index.js
+++ b/index.js
@@ -113,7 +113,8 @@ const ScrollableTabView = React.createClass({
             return <View
               key={child.props.tabLabel + '_' + idx}
               style={{width: this.state.containerWidth, }}>
-              {child}
+              {child.props.hasOwnProperty('passGoToPage') ?
+              React.cloneElement(child, {goToPage: this.goToPage}) : child}
             </View>;
           })}
         </ScrollView>
@@ -135,7 +136,8 @@ const ScrollableTabView = React.createClass({
            return <View
              key={child.props.tabLabel + '_' + idx}
              style={{width: this.state.containerWidth, }}>
-             {child}
+             {child.props.hasOwnProperty('passGoToPage') ?
+              React.cloneElement(child, {goToPage: this.goToPage}) : child}
            </View>;
          })}
         </ViewPagerAndroid>


### PR DESCRIPTION
When set, it will pass `goToPage(index)` as props so that the pages can use it to redirect to another tab.
I found it extremely useful for my use case, where a button will redirect to another tab.
Example:

```
<ScrollableTabView>
    <SomeOtherPage tabLabel="Page 0" />
    <SubmitPage tabLabel="Submit" passGoToPage />
</ScrollableTabView>
```
```
class SubmitPage extends Component {
    ...
    handleSubmit() {
        ...
        if(success) {
            this.props.goToPage(0)
        }
    }
    ...
}
```