### PR TITLE
fix scrollView is undefined bug #143

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See
 - **`tabBarInactiveTextColor`** _(String)_ - color of the default tab bar's text when inactive, defaults to `black`
 - **`style`** _([View.propTypes.style](https://facebook.github.io/react-native/docs/view.html#style))_
 - **`contentProps`** _(Object)_ - props that are applied to root `ScrollView`/`ViewPagerAndroid`. Note that overriding defaults set by the library may break functionality; see the source for details.
-
+- **`width`** defaults to window width, it's needed when ScrollableTabView width is smaller than window width [#143](https://github.com/brentvatne/react-native-scrollable-tab-view/issues/143)
 ---
 
 **MIT Licensed**

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ const ScrollableTabView = React.createClass({
     onScroll: PropTypes.func,
     renderTabBar: PropTypes.any,
     style: View.propTypes.style,
-    contentProps: PropTypes.object
+    contentProps: PropTypes.object,
+    width: PropTypes.number
   },
 
   getDefaultProps() {
@@ -38,7 +39,8 @@ const ScrollableTabView = React.createClass({
       page: -1,
       onChangeTab: () => {},
       onScroll: () => {},
-      contentProps: {}
+      contentProps: {},
+      width: Dimensions.get('window').width
     };
   },
 
@@ -46,7 +48,7 @@ const ScrollableTabView = React.createClass({
     return {
       currentPage: this.props.initialPage,
       scrollValue: new Animated.Value(this.props.initialPage),
-      containerWidth: Dimensions.get('window').width,
+      containerWidth: this.props.width
     };
   },
 


### PR DESCRIPTION
Sometimes it can happend that when width of the ScrollableTabView is different that window width it will go into handle layout change and after comparing width it will call code to recalculate scroll on next interaction, but that is not needed because ScrollableTabView didn't change width at all.

Also problem is that [InteractionManager.runAfterInteractions](https://github.com/brentvatne/react-native-scrollable-tab-view/blob/master/index.js#L166) can be called after Component is already unmounted.
We should probably add check to see if this.scrollView is available before scrolling to the next page.