### PR TITLE
disable scrollsToTop on horizontal scrollView

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ const ScrollableTabView = React.createClass({
             this._updateSelectedPage(parseInt(offsetX / this.state.containerWidth, 10));
           }}
           scrollEventThrottle={16}
+          scrollsToTop={false}
           showsHorizontalScrollIndicator={false}
           scrollEnabled={!this.props.locked}
           directionalLockEnabled


### PR DESCRIPTION
If you nest a scrollView inside scrollableTabView it's not possible to scroll to the top by tapping the statusbar on iOS as the horizontal scrollView hi-jacks scrollsToTop. This pr disables scrollsToTop on the horizontal scrollView.