### PR TITLE
Enabling a textStyle prop for adding custom styles to tab bar text 

### DIFF
--- a/DefaultTabBar.js
+++ b/DefaultTabBar.js
@@ -22,6 +22,7 @@ const DefaultTabBar = React.createClass({
     const isTabActive = this.props.activeTab === page;
     const activeTextColor = this.props.activeTextColor || 'navy';
     const inactiveTextColor = this.props.inactiveTextColor || 'black';
+    const textStyle = this.props.textStyle || {};
 
     return <Button
       key={name}
@@ -31,7 +32,7 @@ const DefaultTabBar = React.createClass({
       onPress={() => this.props.goToPage(page)}
     >
       <View style={styles.tab}>
-        <Text style={{color: isTabActive ? activeTextColor : inactiveTextColor, fontWeight: isTabActive ? 'bold' : 'normal', }}>
+        <Text style={[{color: isTabActive ? activeTextColor : inactiveTextColor, fontWeight: isTabActive ? 'bold' : 'normal', }, textStyle]}>
           {name}
         </Text>
       </View>

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ See
 - **`tabBarBackgroundColor`** _(String)_ - color of the default tab bar's background, defaults to `white`
 - **`tabBarActiveTextColor`** _(String)_ - color of the default tab bar's text when active, defaults to `navy`
 - **`tabBarInactiveTextColor`** _(String)_ - color of the default tab bar's text when inactive, defaults to `black`
+- **`tabBarTextStyle`** _(Object)_ - Additional styles to the tab bar's text. Example: `{fontFamily: 'Roboto', fontSize: 15}`
 - **`style`** _([View.propTypes.style](https://facebook.github.io/react-native/docs/view.html#style))_
 - **`contentProps`** _(Object)_ - props that are applied to root `ScrollView`/`ViewPagerAndroid`. Note that overriding defaults set by the library may break functionality; see the source for details.
 

--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -98,6 +98,7 @@ const ScrollableTabBar = React.createClass({
     const isTabActive = this.props.activeTab === page;
     const activeTextColor = this.props.activeTextColor || 'navy';
     const inactiveTextColor = this.props.inactiveTextColor || 'black';
+    const textStyle = this.props.textStyle || {};
 
     return <TouchableOpacity
       key={name}
@@ -110,7 +111,7 @@ const ScrollableTabBar = React.createClass({
       onLayout={this.measureTab.bind(this, page)}
       >
       <View>
-        <Text style={{color: isTabActive ? activeTextColor : inactiveTextColor, }}>{name}</Text>
+        <Text style={[{color: isTabActive ? activeTextColor : inactiveTextColor}, textStyle]}>{name}</Text>
       </View>
     </TouchableOpacity>;
   },

--- a/index.js
+++ b/index.js
@@ -200,6 +200,9 @@ const ScrollableTabView = React.createClass({
     if (this.props.tabBarInactiveTextColor) {
       tabBarProps.inactiveTextColor = this.props.tabBarInactiveTextColor;
     }
+    if (this.props.tabBarTextStyle) {
+      tabBarProps.textStyle = this.props.tabBarTextStyle;
+    }
     if (overlayTabs) {
       tabBarProps.style = {
         position: 'absolute',


### PR DESCRIPTION
A new prop called `textStyle` is added for handling custom styles for the tab bar text. This can be used if the developer wants to change `fontFamily` and other text styles to match with the current app theme.

Please review and provide feedback