### PR TITLE
Check for presence of 'this.scrollView' before calling scrollTo

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,9 +61,13 @@ const ScrollableTabView = React.createClass({
 
     if (Platform.OS === 'ios') {
       const offset = pageNumber * this.state.containerWidth;
-      this.scrollView.scrollTo({x: offset, y: 0, });
+      if (this.scrollView) {
+        this.scrollView.scrollTo({x: offset, y: 0, });
+      }
     } else {
-      this.scrollView.setPage(pageNumber);
+      if (this.scrollView) {
+        this.scrollView.setPage(pageNumber);
+      }
     }
 
     this.setState({currentPage: pageNumber, });


### PR DESCRIPTION
Excuse the typo in the commit :)

I have an issue where I'm rendering a component using ART that takes a second or so, and on the same screen is a scrollable tab view. If I switch screens before the ART animation is finished, we try to call `scrollTo` on `null`.